### PR TITLE
Compare answers should be made by the index of the selected option and not by text.

### DIFF
--- a/js/slickQuiz.js
+++ b/js/slickQuiz.js
@@ -311,7 +311,7 @@
                         var answer = answers[i];
 
                         if (answer.correct) {
-                            trueAnswers.push($('<div />').html(answer.option).text());
+                            trueAnswers.push(parseInt(i, 10));
                         }
                     }
                 }
@@ -322,8 +322,8 @@
                 // Collect the answers submitted
                 var selectedAnswers = [];
                 answerInputs.each( function() {
-                    var inputValue = $(this).next('label').text();
-                    selectedAnswers.push(inputValue);
+                    var id = $(this).attr('id');
+                    selectedAnswers.push(parseInt(id.replace(/(question\d{1,}_)/, ''), 10));
                 });
 
                 if (plugin.config.preventUnanswered && selectedAnswers.length === 0) {


### PR DESCRIPTION
The compare answers should be made by the index of the selected option and not by text.
Let's suppose someone is using the mathjax library to display LaTeX expressions in HTML source code.
The compare answers will fail because the label text is changed by the mathjax library.
