### PR TITLE
Force checkboxes

### DIFF
--- a/js/slickQuiz.js
+++ b/js/slickQuiz.js
@@ -255,8 +255,9 @@
 
                         // prepare a name for the answer inputs based on the question
                         var selectAny  = question.select_any ? question.select_any : false,
-                            inputName  = 'question' + (count - 1),
-                            inputType  = (truths > 1 && !selectAny ? 'checkbox' : 'radio');
+                            forceCheckbox = question.force_checkbox ? question.force_checkbox : false,
+                            inputName     = 'question' + (count - 1),
+                            inputType     = (((truths > 1 && !selectAny) || forceCheckbox) ? 'checkbox' : 'radio');
 
                         if( count == quizValues.questions.length ) {
                             nextQuestionClass = nextQuestionClass + ' ' + lastQuestionClass;


### PR DESCRIPTION
A new variable for questions to force checkboxes even if only one answer is
true. For if you **don't** want to give the user a hint that only one answer is true. Maybe he then selects 2 checkboxes although only one answer is true. With radios this was not possible with force_checkbox this now is possible.

Set the variable true in your quizJSON for every question you want to force checkboxes

``` javascript
...
"force_checkbox": true,
...
```
