### PR TITLE
New css class for answers

### DIFF
--- a/js/slickQuiz.js
+++ b/js/slickQuiz.js
@@ -57,6 +57,7 @@
             answersClass           = 'answers',
             responsesClass         = 'responses',
             correctClass           = 'correctResponse',
+            incorrectClass         = 'incorrectResponse',
             correctResponseClass   = 'correct',
             incorrectResponseClass = 'incorrect',
             checkAnswerClass       = 'checkAnswer',
@@ -265,7 +266,8 @@
                         for (i in answers) {
                             if (answers.hasOwnProperty(i)) {
                                 answer   = answers[i],
-                                optionId = inputName + '_' + i.toString();
+                                optionId = inputName + '_' + i.toString(),
+                                answerStatus = answer.correct ? correctResponseClass : incorrectResponseClass;
 
                                 // If question has >1 true answers and is not a select any, use checkboxes; otherwise, radios
                                 var input = '<input id="' + optionId + '" name="' + inputName +
@@ -273,7 +275,7 @@
 
                                 var optionLabel = '<label for="' + optionId + '">' + answer.option + '</label>';
 
-                                var answerContent = $('<li></li>')
+                                var answerContent = $('<li class="' + answerStatus + '"></li>')
                                     .append(input)
                                     .append(optionLabel);
                                 answerHTML.append(answerContent);
@@ -442,6 +444,8 @@
 
                 if (correctResponse) {
                     questionLI.addClass(correctClass);
+                } else {
+                    questionLI.addClass(incorrectClass);
                 }
 
                 // Toggle appropriate response (either for display now and / or on completion)


### PR DESCRIPTION
A class **correct** or **incorrect** for each answer. To visualy point out
the answer status in quizResults to give the user a chance to learn
right answers and then run the test again.

Additionaly a class **incorrectResponse** as counterpart to **correctResponse** for li.question in quizResult.

See #43
